### PR TITLE
Some cleaning and a potential performance boost

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,11 @@ cmake_minimum_required(VERSION 2.8)
 
 project(simdcsv)
 
+if (NOT CMAKE_BUILD_TYPE)
+                message(STATUS "No build type selected, default to Release")
+                set(CMAKE_BUILD_TYPE Release CACHE STRING "Choose the type of build." FORCE)
+endif()
+
 set(CMAKE_BINARY_DIR ${CMAKE_SOURCE_DIR}/bin)
 
 include_directories("${PROJECT_SOURCE_DIR}/src")
@@ -15,4 +20,30 @@ set(CMAKE_CXX_FLAGS_RELWITHDEBINFO   "-O3 -g")
 set(CMAKE_CXX_FLAGS_RELEASE          "-O3")
 set(CMAKE_CXX_FLAGS_DEBUG            "-DDEBUG -O0 -g")
 
+# evidently useful:
+macro(append var string)
+  set(${var} "${${var}} ${string}")
+endmacro(append)
+
+# To build with sanitizers, do cmake  -DSIMDCSV_SANITIZE=ON ..
+if(SIMDCSV_SANITIZE)
+  set(SIMDCSV_SANITIZE_FLAGS "-fsanitize=address -fno-omit-frame-pointer -fsanitize=undefined -fno-sanitize-recover=all")
+  if (CMAKE_COMPILER_IS_GNUCC)
+    # Ubuntu bug for GCC 5.0+ (safe for all versions)
+    append(CMAKE_EXE_LINKER_FLAGS "-fuse-ld=gold")
+    append(CMAKE_SHARED_LINKER_FLAGS "-fuse-ld=gold")
+  endif()
+  append(CMAKE_CXX_FLAGS ${SIMDCSV_SANITIZE_FLAGS})
+  MESSAGE( STATUS "Sanitizers requested.")
+endif()
+
 add_executable(simdcsv ${SOURCES})
+
+# Are you sure you know the settings? Let us print them out:
+MESSAGE( STATUS "CMAKE_SYSTEM_PROCESSOR: " ${CMAKE_SYSTEM_PROCESSOR})
+MESSAGE( STATUS "CMAKE_BUILD_TYPE: " ${CMAKE_BUILD_TYPE} )
+
+MESSAGE( STATUS "CMAKE_CXX_COMPILER: " ${CMAKE_CXX_COMPILER} ) # important to know which compiler is used
+MESSAGE( STATUS "CMAKE_CXX_FLAGS: " ${CMAKE_CXX_FLAGS} ) # important to know the flags
+MESSAGE( STATUS "CMAKE_CXX_FLAGS_DEBUG: " ${CMAKE_CXX_FLAGS_DEBUG} )
+MESSAGE( STATUS "CMAKE_CXX_FLAGS_RELEASE: " ${CMAKE_CXX_FLAGS_RELEASE} )

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -100,9 +100,9 @@ really_inline uint64_t find_quote_mask(simd_input in, uint64_t &prev_iter_inside
 // needs to be large enough to handle this
 really_inline void flatten_bits(uint32_t *base_ptr, uint32_t &base,
                                 uint32_t idx, uint64_t bits) {
-  uint32_t cnt = hamming(bits);
-  uint32_t next_base = base + cnt;
-  while (bits != 0u) {
+  if (bits != 0u) {
+    uint32_t cnt = hamming(bits);
+    uint32_t next_base = base + cnt;
     base_ptr[base + 0] = static_cast<uint32_t>(idx) + trailingzeroes(bits);
     bits = bits & (bits - 1);
     base_ptr[base + 1] = static_cast<uint32_t>(idx) + trailingzeroes(bits);
@@ -119,9 +119,34 @@ really_inline void flatten_bits(uint32_t *base_ptr, uint32_t &base,
     bits = bits & (bits - 1);
     base_ptr[base + 7] = static_cast<uint32_t>(idx) + trailingzeroes(bits);
     bits = bits & (bits - 1);
-    base += 8;
+    if (cnt > 8) {
+      base_ptr[base + 8] = static_cast<uint32_t>(idx) + trailingzeroes(bits);
+      bits = bits & (bits - 1);
+      base_ptr[base + 9] = static_cast<uint32_t>(idx) + trailingzeroes(bits);
+      bits = bits & (bits - 1);
+      base_ptr[base + 10] = static_cast<uint32_t>(idx) + trailingzeroes(bits);
+      bits = bits & (bits - 1);
+      base_ptr[base + 11] = static_cast<uint32_t>(idx) + trailingzeroes(bits);
+      bits = bits & (bits - 1);
+      base_ptr[base + 12] = static_cast<uint32_t>(idx) + trailingzeroes(bits);
+      bits = bits & (bits - 1);
+      base_ptr[base + 13] = static_cast<uint32_t>(idx) + trailingzeroes(bits);
+      bits = bits & (bits - 1);
+      base_ptr[base + 14] = static_cast<uint32_t>(idx) + trailingzeroes(bits);
+      bits = bits & (bits - 1);
+      base_ptr[base + 15] = static_cast<uint32_t>(idx) + trailingzeroes(bits);
+      bits = bits & (bits - 1);
+    }
+    if (cnt > 16) {
+      base += 16;
+      do {
+        base_ptr[base] = static_cast<uint32_t>(idx) + trailingzeroes(bits);
+        bits = bits & (bits - 1);
+        base++;
+      } while (bits != 0);
+    }
+    base = next_base;
   }
-  base = next_base;
 }
 
 //
@@ -202,7 +227,6 @@ bool find_indexes(const uint8_t * buf, size_t len, ParsedCSV & pcsv) {
     // the quoted bits here. Some other quote convention would
     // need to be thought about carefully
       uint64_t field_sep = (end | sep) & ~quote_mask;
-
       flatten_bits(base_ptr, base, idx, field_sep);
   }
 #undef SIMDCSV_BUFFERSIZE

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -136,7 +136,7 @@ bool find_indexes(const uint8_t * buf, size_t len, ParsedCSV & pcsv) {
 #define SIMDCSV_BUFFERSIZE 4
   if(lenminus64 > 64 * SIMDCSV_BUFFERSIZE) {
     uint64_t fields[SIMDCSV_BUFFERSIZE];
-    for (; idx < lenminus64; idx += 64 * SIMDCSV_BUFFERSIZE) {
+    for (; idx < lenminus64 - 64 * SIMDCSV_BUFFERSIZE + 1; idx += 64 * SIMDCSV_BUFFERSIZE) {
       for(size_t b = 0; b < SIMDCSV_BUFFERSIZE; b++){
         size_t internal_idx = 64 * b + idx;
 #ifndef _MSC_VER

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -132,32 +132,63 @@ bool find_indexes(const uint8_t * buf, size_t len, ParsedCSV & pcsv) {
   size_t idx = 0;
   uint32_t *base_ptr = pcsv.indexes;
   uint32_t base = 0;
-
-  for (; idx < lenminus64; idx += 64) {
+  // we do the index decoding in bulk for better pipelining.
+#define SIMDCSV_BUFFERSIZE 4
+  if(lenminus64 > 64 * SIMDCSV_BUFFERSIZE) {
+    uint64_t fields[SIMDCSV_BUFFERSIZE];
+    for (; idx < lenminus64; idx += 64 * SIMDCSV_BUFFERSIZE) {
+      for(size_t b = 0; b < SIMDCSV_BUFFERSIZE; b++){
+        size_t internal_idx = 64 * b + idx;
 #ifndef _MSC_VER
-    __builtin_prefetch(buf + idx + 128);
+        __builtin_prefetch(buf + internal_idx + 128);
 #endif
-    simd_input in = fill_input(buf+idx);
-    uint64_t quote_mask = find_quote_mask(in, prev_iter_inside_quote);
-    uint64_t sep = cmp_mask_against_input(in, ',');
+        simd_input in = fill_input(buf+internal_idx);
+        uint64_t quote_mask = find_quote_mask(in, prev_iter_inside_quote);
+        uint64_t sep = cmp_mask_against_input(in, ',');
 #ifdef CRLF
-    uint64_t cr = cmp_mask_against_input(in, 0x0d);
-    uint64_t cr_adjusted = (cr << 1) | prev_iter_cr_end;
-    uint64_t lf = cmp_mask_against_input(in, 0x0a);
-    uint64_t end = lf & cr_adjusted;
-    prev_iter_cr_end = cr >> 63;
+        uint64_t cr = cmp_mask_against_input(in, 0x0d);
+        uint64_t cr_adjusted = (cr << 1) | prev_iter_cr_end;
+        uint64_t lf = cmp_mask_against_input(in, 0x0a);
+        uint64_t end = lf & cr_adjusted;
+        prev_iter_cr_end = cr >> 63;
 #else
-    uint64_t end = cmp_mask_against_input(in, 0x0a);
+        uint64_t end = cmp_mask_against_input(in, 0x0a);
+#endif
+        fields[b] = (end | sep) & ~quote_mask;
+      }
+      for(size_t b = 0; b < SIMDCSV_BUFFERSIZE; b++){
+        size_t internal_idx = 64 * b + idx;
+        flatten_bits(base_ptr, base, internal_idx, fields[b]);
+      }
+    }
+    // tail end
+    for (; idx < lenminus64; idx += 64) {
+#ifndef _MSC_VER
+      __builtin_prefetch(buf + idx + 128);
+#endif
+      simd_input in = fill_input(buf+idx);
+      uint64_t quote_mask = find_quote_mask(in, prev_iter_inside_quote);
+      uint64_t sep = cmp_mask_against_input(in, ',');
+#ifdef CRLF
+      uint64_t cr = cmp_mask_against_input(in, 0x0d);
+      uint64_t cr_adjusted = (cr << 1) | prev_iter_cr_end;
+      uint64_t lf = cmp_mask_against_input(in, 0x0a);
+      uint64_t end = lf & cr_adjusted;
+      prev_iter_cr_end = cr >> 63;
+#else
+      uint64_t end = cmp_mask_against_input(in, 0x0a);
 #endif
     // note - a bit of a high-wire act here with quotes
     // we can't put something inside the quotes with the CR
     // then outside the quotes with LF so it's OK to "and off"
     // the quoted bits here. Some other quote convention would
     // need to be thought about carefully
-    uint64_t field_sep = (end | sep) & ~quote_mask;
+      uint64_t field_sep = (end | sep) & ~quote_mask;
 
-    flatten_bits(base_ptr, base, idx, field_sep);
+      flatten_bits(base_ptr, base, idx, field_sep);
+    }
   }
+#undef SIMDCSV_BUFFERSIZE
   pcsv.n_indexes = base;
   return true;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -251,8 +251,10 @@ int main(int argc, char * argv[]) {
       }
       cout << "\n";
     }
-  } else if(verbose) {
-    cout << "number of indexes found : " << pcsv.n_indexes << endl;
+  } 
+  if(verbose) {
+    cout << "number of indexes found    : " << pcsv.n_indexes << endl;
+    cout << "number of bytes per index : " << p.size() / double(pcsv.n_indexes) << endl;
   }
   double volume = iterations * p.size();
   double time_in_s = total / CLOCKS_PER_SEC;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -197,8 +197,8 @@ int main(int argc, char * argv[]) {
   int c; 
   bool verbose = false;
   bool dump = false;
-  int iterations = 10;
-  bool squash_counters = false; // unused.
+  size_t iterations = 100;
+  //bool squash_counters = false; // unused.
 
   while ((c = getopt(argc, argv, "vdi:s")) != -1){
     switch (c) {
@@ -212,7 +212,8 @@ int main(int argc, char * argv[]) {
       iterations = atoi(optarg);
       break;
     case 's':
-      squash_counters = true;
+      //squash_counters = true;
+      cerr << "unused parameter?" << endl;
       break;
     }
   }
@@ -260,7 +261,7 @@ int main(int argc, char * argv[]) {
   TimingAccumulator ta(2, evts);
 #endif // __linux__
   double total = 0; // naive accumulator
-  for (int i = 0; i < iterations; i++) {
+  for (size_t i = 0; i < iterations; i++) {
       clock_t start = clock(); // brutally portable
 #ifdef __linux__
       {TimingPhase p1(ta, 0);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -140,7 +140,9 @@ really_inline void flatten_bits(uint32_t *base_ptr, uint32_t &base,
 bool find_indexes(const uint8_t * buf, size_t len, ParsedCSV & pcsv) {
   // does the previous iteration end inside a double-quote pair?
   uint64_t prev_iter_inside_quote = 0ULL;  // either all zeros or all ones
-  //uint64_t prev_iter_cr_end = 0ULL; 
+#ifdef CRLF
+  uint64_t prev_iter_cr_end = 0ULL; 
+#endif
   size_t lenminus64 = len < 64 ? 0 : len - 64;
   size_t idx = 0;
   uint32_t *base_ptr = pcsv.indexes;

--- a/src/timing.h
+++ b/src/timing.h
@@ -1,6 +1,7 @@
 #ifndef TIMING_H
 #define TIMING_H
 
+#ifdef __linux__
 #include <asm/unistd.h>       // for __NR_perf_event_open
 #include <linux/perf_event.h> // for perf event constants
 #include <sys/ioctl.h>        // for ioctl
@@ -119,5 +120,6 @@ public:
     acc.stop(phase_number);
   }
 };
+#endif // __linux__
 
 #endif

--- a/src/timing.h
+++ b/src/timing.h
@@ -42,6 +42,7 @@ public:
 
     int group = -1; // no group
     num_events = config_vec.size();
+    ids.resize(config_vec.size());
     uint32_t i = 0;
     for (auto config : config_vec) {
       attribs.config = config;
@@ -84,7 +85,7 @@ public:
       report_error("ioctl(PERF_EVENT_IOC_DISABLE)");
     }
 
-    if (read(fd, &temp_result_vec[0], temp_result_vec.size() * 8) == -1) {
+    if (read(fd, temp_result_vec.data(), temp_result_vec.size() * 8) == -1) {
       report_error("read");
     }
     // our actual results are in slots 1,3,5, ... of this structure


### PR DESCRIPTION
The flattening function is hard to beat (by a lot) on its own, and if you benchmark it in isolation, it does great. However, calling it at a 64-bit word granularity seems to be tricky. The best I could measure was 2 instruction per cycle, if that, and the low instruction count per cycle seems to be entirely due to the flatten function.

See:

```
$ ./simdcsv ../examples/nfl.csv
Number of instructions per byte    = 1.44558
Number of instructions per cycle   = 2.08497
Cycles per byte 0.694172
 GB/s: 4.26847
```

We need to use it strategically. 

As a brute force fix, you can just unroll the loop and call it within a tight look, it seems to help.

```
$ ./simdcsv -v ../examples/nfl.csv
Number of instructions per byte    = 1.4456
Number of instructions per cycle   = 2.59418
Cycles per byte 0.557247
 GB/s: 5.23192
```
So that's a 25% gain in the number of instructions per cycle which translates into a comparable speed gain.

Obviously,   2.59418 is still not great. One would hope to reach 3...

I think that a speed of 6 GB/s is possible.