### PR TITLE
pad string view

### DIFF
--- a/src/io_util.cpp
+++ b/src/io_util.cpp
@@ -29,7 +29,7 @@ std::basic_string_view<uint8_t> get_corpus(const std::string& filename, size_t p
       aligned_free(buf);
       throw  std::runtime_error("could not read the data");
     }
-    return std::basic_string_view<uint8_t>(buf,len);
+    return std::basic_string_view<uint8_t>(buf, len+padding);
   }
   throw  std::runtime_error("could not load corpus");
 }


### PR DESCRIPTION
```
% cat test.csv 
aaa1,bbb,ccc,111,222,333,1.11,2.22,3.33
aaa2,bbb,ccc,111,222,333,1.11,2.22,3.33

% ./simdcsv -d -i 1 -v test.csv
[verbose] loading test.csv
[verbose] loaded test.csv (80 bytes)
4: ,bbb
8: ,ccc
12: ,111
16: ,222
20: ,333
24: ,1.11
29: ,2.22
34: ,3.33
39: 
aaa2
44: ,bbb
48: ,ccc
52: ,111
56: ,222
60:  <--------- didn't parse the last few fields, w/o padding the basic_string_view
number of indexes found    : 14
number of bytes per index : 5.71429
Total time in (s)          = 1e-06
Number of iterations       = 80
 GB/s: 0.0745058
[verbose] done
```